### PR TITLE
Remove required attributes from fields like *_en in UA dialogue

### DIFF
--- a/openprocurement/tender/competitivedialogue/models.py
+++ b/openprocurement/tender/competitivedialogue/models.py
@@ -6,14 +6,12 @@ from schematics.types.compound import ModelType
 from openprocurement.api.models import ITender
 from openprocurement.tender.openua.models import SifterListType, Item as BaseItem
 from openprocurement.tender.openeu.models import (Tender as TenderEU, Administrator_bid_role, view_bid_role,
-                                                  Identifier as BaseIdentifier,
-                                                  Organization as BaseOrganization,
-                                                  ContactPoint as BaseContactPoint,
-                                                  Bid as BidEU, ConfidentialDocument)
+                                                  Organization as BaseOrganization, Bid as BidEU, ConfidentialDocument)
 from openprocurement.api.models import (
     plain_role, create_role, edit_role, view_role, listing_role,
     enquiries_role, validate_cpv_group, validate_items_uniq,
     chronograph_role, chronograph_view_role,
+    Identifier as BaseIdentifier, ContactPoint as BaseContactPoint,
     Administrator_role, schematics_default_role,
     schematics_embedded_role, ListType, BooleanType
 )
@@ -45,24 +43,12 @@ roles = {
 }
 
 
-class Identifier(BaseIdentifier):
-    """Redefinition model Identifier for UA dialogue"""
-
-    legalName_en = StringType()  # not required for UA dialogue
-
-
-class ContactPoint(BaseContactPoint):
-    """Redefinition model ContactPoint for UA dialogue"""
-
-    name_en = StringType()  # not required for UA dialogue
-
-
 class Organization(BaseOrganization):
     """Redefinition model Organization for UA dialogue"""
 
     name_en = StringType()  # not required for UA dialogue
-    identifier = ModelType(Identifier, required=True)
-    contactPoint = ModelType(ContactPoint, required=True)
+    identifier = ModelType(BaseIdentifier, required=True)
+    contactPoint = ModelType(BaseContactPoint, required=True)
 
 
 class ProcuringEntity(Organization):
@@ -76,12 +62,6 @@ class ProcuringEntity(Organization):
         }
 
     kind = StringType(choices=['general', 'special', 'defense', 'other'])
-
-
-class Item(BaseItem):
-    """Redefinition object Item for UA dialogue"""
-
-    description_en = StringType()
 
 
 class Document(ConfidentialDocument):
@@ -157,7 +137,7 @@ CompetitiveDialogEU = Tender
 class Tender(CompetitiveDialogEU):
     procurementMethodType = StringType(default="competitiveDialogue.aboveThresholdUA")
     title_en = StringType()
-    items = ListType(ModelType(Item), required=True, min_size=1,
+    items = ListType(ModelType(BaseItem), required=True, min_size=1,
                      validators=[validate_cpv_group, validate_items_uniq])
     procuringEntity = ModelType(ProcuringEntity, required=True)
 

--- a/openprocurement/tender/competitivedialogue/models.py
+++ b/openprocurement/tender/competitivedialogue/models.py
@@ -10,8 +10,7 @@ from openprocurement.tender.openeu.models import (Tender as TenderEU, Administra
 from openprocurement.api.models import (
     plain_role, create_role, edit_role, view_role, listing_role,
     enquiries_role, validate_cpv_group, validate_items_uniq,
-    chronograph_role, chronograph_view_role,
-    Identifier as BaseIdentifier, ContactPoint as BaseContactPoint,
+    chronograph_role, chronograph_view_role, ProcuringEntity as BaseProcuringEntity,
     Administrator_role, schematics_default_role,
     schematics_embedded_role, ListType, BooleanType
 )
@@ -41,28 +40,6 @@ roles = {
     'default': schematics_default_role,
     'contracting': whitelist('doc_id', 'owner'),
 }
-
-
-class Organization(BaseOrganization):
-    """Redefinition model Organization for UA dialogue"""
-
-    name_en = StringType()  # not required for UA dialogue
-    identifier = ModelType(BaseIdentifier, required=True)
-    contactPoint = ModelType(BaseContactPoint, required=True)
-
-
-class ProcuringEntity(Organization):
-    """Redefinition model ProcuringEntity for UA dialogue"""
-
-    class Options:
-        roles = {
-            'embedded': schematics_embedded_role,
-            'view': schematics_default_role,
-            'edit_active.tendering': schematics_default_role + blacklist("kind"),
-        }
-
-    kind = StringType(choices=['general', 'special', 'defense', 'other'])
-
 
 class Document(ConfidentialDocument):
     """ Document model with new feature as Description of the decision to purchase """
@@ -139,7 +116,7 @@ class Tender(CompetitiveDialogEU):
     title_en = StringType()
     items = ListType(ModelType(BaseItem), required=True, min_size=1,
                      validators=[validate_cpv_group, validate_items_uniq])
-    procuringEntity = ModelType(ProcuringEntity, required=True)
+    procuringEntity = ModelType(BaseProcuringEntity, required=True)
 
 
 CompetitiveDialogUA = Tender

--- a/openprocurement/tender/competitivedialogue/models.py
+++ b/openprocurement/tender/competitivedialogue/models.py
@@ -1,22 +1,21 @@
 # -*- coding: utf-8 -*-
-from datetime import timedelta
 from schematics.types import StringType
 from schematics.exceptions import ValidationError
 from zope.interface import implementer
 from schematics.types.compound import ModelType
-from openprocurement.api.models import ITender, get_now
-from openprocurement.tender.openua.models import Tender as TenderUA, SifterListType
-from openprocurement.tender.openeu.models import Tender as TenderEU, Administrator_bid_role, view_bid_role
-from openprocurement.tender.openeu.models import TENDERING_DAYS, TENDERING_DURATION
-from openprocurement.tender.openua.utils import calculate_business_date
-from openprocurement.tender.openeu.models import Bid as BidEU, ConfidentialDocument
+from openprocurement.api.models import ITender
+from openprocurement.tender.openua.models import SifterListType, Item as BaseItem
+from openprocurement.tender.openeu.models import (Tender as TenderEU, Administrator_bid_role, view_bid_role,
+                                                  Identifier as BaseIdentifier,
+                                                  Organization as BaseOrganization,
+                                                  ContactPoint as BaseContactPoint,
+                                                  Bid as BidEU, ConfidentialDocument)
 from openprocurement.api.models import (
     plain_role, create_role, edit_role, view_role, listing_role,
-    enquiries_role,
+    enquiries_role, validate_cpv_group, validate_items_uniq,
     chronograph_role, chronograph_view_role,
     Administrator_role, schematics_default_role,
-    get_now, schematics_embedded_role, draft_role,
-    ListType, BooleanType
+    schematics_embedded_role, ListType, BooleanType
 )
 from schematics.transforms import whitelist, blacklist
 from openprocurement.tender.openeu.models import pre_qualifications_role
@@ -46,8 +45,47 @@ roles = {
 }
 
 
+class Identifier(BaseIdentifier):
+    """Redefinition model Identifier for UA dialogue"""
+
+    legalName_en = StringType()  # not required for UA dialogue
+
+
+class ContactPoint(BaseContactPoint):
+    """Redefinition model ContactPoint for UA dialogue"""
+
+    name_en = StringType()  # not required for UA dialogue
+
+
+class Organization(BaseOrganization):
+    """Redefinition model Organization for UA dialogue"""
+
+    name_en = StringType()  # not required for UA dialogue
+    identifier = ModelType(Identifier, required=True)
+    contactPoint = ModelType(ContactPoint, required=True)
+
+
+class ProcuringEntity(Organization):
+    """Redefinition model ProcuringEntity for UA dialogue"""
+
+    class Options:
+        roles = {
+            'embedded': schematics_embedded_role,
+            'view': schematics_default_role,
+            'edit_active.tendering': schematics_default_role + blacklist("kind"),
+        }
+
+    kind = StringType(choices=['general', 'special', 'defense', 'other'])
+
+
+class Item(BaseItem):
+    """Redefinition object Item for UA dialogue"""
+
+    description_en = StringType()
+
+
 class Document(ConfidentialDocument):
-    """ Description of the decision to purchase """
+    """ Document model with new feature as Description of the decision to purchase """
 
     class Options:
         roles = {
@@ -92,6 +130,7 @@ class Bid(BidEU):
             'invalid': whitelist('id', 'status'),
             'deleted': whitelist('id', 'status'),
         }
+
     documents = ListType(ModelType(Document), default=list())
 
 
@@ -113,9 +152,14 @@ class Tender(TenderEU):
 
 CompetitiveDialogEU = Tender
 
+
 @implementer(ITender)
 class Tender(CompetitiveDialogEU):
     procurementMethodType = StringType(default="competitiveDialogue.aboveThresholdUA")
     title_en = StringType()
+    items = ListType(ModelType(Item), required=True, min_size=1,
+                     validators=[validate_cpv_group, validate_items_uniq])
+    procuringEntity = ModelType(ProcuringEntity, required=True)
+
 
 CompetitiveDialogUA = Tender

--- a/openprocurement/tender/competitivedialogue/tests/tender.py
+++ b/openprocurement/tender/competitivedialogue/tests/tender.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from openprocurement.api.models import get_now, SANDBOX_MODE
 from openprocurement.api.utils import ROUTE_PREFIX
 from openprocurement.api.tests.base import BaseWebTest, test_organization
-from openprocurement.tender.competitivedialogue.models import TenderUA, TenderEU
+from openprocurement.tender.competitivedialogue.models import CompetitiveDialogUA, CompetitiveDialogEU
 
 from openprocurement.tender.competitivedialogue.tests.base import (test_tender_data_ua,
                                                                    test_tender_data_eu,
@@ -16,7 +16,7 @@ from copy import deepcopy
 class CompetitiveDialogTest(BaseWebTest):
 
     def test_simple_add_tender_ua(self):
-        u = TenderUA(test_tender_data_ua)
+        u = CompetitiveDialogUA(test_tender_data_ua)
         u.tenderID = "UA-X"
 
         assert u.id is None
@@ -36,7 +36,7 @@ class CompetitiveDialogTest(BaseWebTest):
         u.delete_instance(self.db)
 
     def test_simple_add_tender_eu(self):
-        u = TenderEU(test_tender_data_eu)
+        u = CompetitiveDialogEU(test_tender_data_eu)
         u.tenderID = "UA-X"
 
         assert u.id is None


### PR DESCRIPTION
Для діалогу по UA гілці прибрано обов'язковість полів 
item[*].description_en
procuringEntity.name_en
procuringEntity.identifier.legalName_en
procuringEntity.contactPoint.name_en

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.tender.competitivedialogue/5)
<!-- Reviewable:end -->
