### PR TITLE
Rename procurementMethodType

### DIFF
--- a/openprocurement/tender/competitivedialogue/models.py
+++ b/openprocurement/tender/competitivedialogue/models.py
@@ -6,7 +6,7 @@ from schematics.types.compound import ModelType
 from openprocurement.api.models import ITender
 from openprocurement.tender.openua.models import SifterListType, Item as BaseItem
 from openprocurement.tender.openeu.models import (Tender as TenderEU, Administrator_bid_role, view_bid_role,
-                                                  Organization as BaseOrganization, Bid as BidEU, ConfidentialDocument)
+                                                  pre_qualifications_role, Bid as BidEU, ConfidentialDocument)
 from openprocurement.api.models import (
     plain_role, create_role, edit_role, view_role, listing_role,
     enquiries_role, validate_cpv_group, validate_items_uniq,
@@ -15,7 +15,10 @@ from openprocurement.api.models import (
     schematics_embedded_role, ListType, BooleanType
 )
 from schematics.transforms import whitelist, blacklist
-from openprocurement.tender.openeu.models import pre_qualifications_role
+
+# constants for procurementMethodtype
+CD_UA_TYPE = "competitiveDialogueUA"
+CD_EU_TYPE = "competitiveDialogueEU"
 
 edit_role_ua = edit_role + blacklist('enquiryPeriod', 'status')
 
@@ -93,7 +96,7 @@ class Bid(BidEU):
 
 @implementer(ITender)
 class Tender(TenderEU):
-    procurementMethodType = StringType(default="competitiveDialogue.aboveThresholdEU")
+    procurementMethodType = StringType(default=CD_EU_TYPE)
     status = StringType(choices=['draft', 'active.tendering', 'active.pre-qualification',
                                  'active.pre-qualification.stand-still', 'active.stage2.pending',
                                  'active.stage2.waiting', 'complete', 'cancelled', 'unsuccessful'],
@@ -112,7 +115,7 @@ CompetitiveDialogEU = Tender
 
 @implementer(ITender)
 class Tender(CompetitiveDialogEU):
-    procurementMethodType = StringType(default="competitiveDialogue.aboveThresholdUA")
+    procurementMethodType = StringType(default=CD_UA_TYPE)
     title_en = StringType()
     items = ListType(ModelType(BaseItem), required=True, min_size=1,
                      validators=[validate_cpv_group, validate_items_uniq])

--- a/openprocurement/tender/competitivedialogue/tests/base.py
+++ b/openprocurement/tender/competitivedialogue/tests/base.py
@@ -14,13 +14,14 @@ from openprocurement.tender.openeu.tests.base import (test_tender_data as base_t
                                                       test_features_tender_data,
                                                       test_bids,
                                                       test_bids as test_bids_eu)
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 now = datetime.now()
 test_tender_data_eu = deepcopy(base_test_tender_data_eu)
-test_tender_data_eu["procurementMethodType"] = "competitiveDialogue.aboveThresholdEU"
+test_tender_data_eu["procurementMethodType"] = CD_EU_TYPE
 test_tender_data_ua = deepcopy(base_test_tender_data_eu)
 del test_tender_data_ua["title_en"]
-test_tender_data_ua["procurementMethodType"] = "competitiveDialogue.aboveThresholdUA"
+test_tender_data_ua["procurementMethodType"] = CD_UA_TYPE
 test_tender_data_ua["tenderPeriod"]["endDate"] = (now + timedelta(days=31)).isoformat()
 
 
@@ -373,4 +374,4 @@ class BaseCompetitiveDialogEUContentWebTest(BaseCompetitiveDialogEUWebTest):
 
 
 test_features_tender_eu_data = test_features_tender_data.copy()
-test_features_tender_eu_data['procurementMethodType'] = "competitiveDialogue.aboveThresholdEU"
+test_features_tender_eu_data['procurementMethodType'] = CD_EU_TYPE

--- a/openprocurement/tender/competitivedialogue/tests/tender.py
+++ b/openprocurement/tender/competitivedialogue/tests/tender.py
@@ -11,7 +11,7 @@ from openprocurement.tender.competitivedialogue.tests.base import (test_tender_d
                                                                    BaseCompetitiveDialogEUWebTest,
                                                                    BaseCompetitiveDialogUAWebTest)
 from copy import deepcopy
-
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 class CompetitiveDialogTest(BaseWebTest):
 
@@ -31,7 +31,7 @@ class CompetitiveDialogTest(BaseWebTest):
 
         assert u.tenderID == fromdb['tenderID']
         assert u.doc_type == "Tender"
-        assert u.procurementMethodType == "competitiveDialogue.aboveThresholdUA"
+        assert u.procurementMethodType == CD_UA_TYPE
 
         u.delete_instance(self.db)
 
@@ -51,7 +51,7 @@ class CompetitiveDialogTest(BaseWebTest):
 
         assert u.tenderID == fromdb['tenderID']
         assert u.doc_type == "Tender"
-        assert u.procurementMethodType == "competitiveDialogue.aboveThresholdEU"
+        assert u.procurementMethodType == CD_EU_TYPE
 
         u.delete_instance(self.db)
 

--- a/openprocurement/tender/competitivedialogue/views/bid.py
+++ b/openprocurement/tender/competitivedialogue/views/bid.py
@@ -1,21 +1,13 @@
 # -*- coding: utf-8 -*-
-from openprocurement.api.models import get_now
-from openprocurement.api.validation import validate_patch_bid_data
-from openprocurement.api.utils import (
-    apply_patch,
-    opresource,
-    save_tender,
-    json_view,
-    context_unpack,
-)
-from openprocurement.tender.openua.views.bid import TenderUABidResource as BaseResourceUA
+from openprocurement.api.utils import opresource
 from openprocurement.tender.openeu.views.bid import TenderBidResource as BaseResourceEU
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @opresource(name='Competitive Dialogue EU Bids',
             collection_path='/tenders/{tender_id}/bids',
             path='/tenders/{tender_id}/bids/{bid_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdEU',
+            procurementMethodType=CD_EU_TYPE,
             description="Competitive Dialogue EU bids")
 class CompetitiveDialogueEUBidResource(BaseResourceEU):
     """ Tender EU bids """
@@ -25,9 +17,8 @@ class CompetitiveDialogueEUBidResource(BaseResourceEU):
 @opresource(name='Competitive Dialogue UA Bids',
             collection_path='/tenders/{tender_id}/bids',
             path='/tenders/{tender_id}/bids/{bid_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdUA',
+            procurementMethodType=CD_UA_TYPE,
             description="Competitive Dialogue UA bids")
 class CompetitiveDialogueUABidResource(BaseResourceEU):
-    """ Tender EU bids """
+    """ Tender UA bids """
     pass
-

--- a/openprocurement/tender/competitivedialogue/views/bid_document.py
+++ b/openprocurement/tender/competitivedialogue/views/bid_document.py
@@ -1,20 +1,14 @@
 # -*- coding: utf-8 -*-
-from openprocurement.api.models import get_now
-from openprocurement.api.utils import (
-    opresource
-)
+from openprocurement.api.utils import opresource
 from openprocurement.tender.openeu.views.bid_document import TenderEUBidDocumentResource
-from openprocurement.tender.openeu.utils import (
-    bid_financial_documents_resource, bid_eligibility_documents_resource,
-    bid_qualification_documents_resource,
-)
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @opresource(
     name='Competitive Dialogue EU Bid Documents',
     collection_path='/tenders/{tender_id}/bids/{bid_id}/documents',
     path='/tenders/{tender_id}/bids/{bid_id}/documents/{document_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdEU',
+    procurementMethodType=CD_EU_TYPE,
     description="Competitive Dialogue EU bidder documents")
 class CompetitiveDialogueEUBidDocumentResource(TenderEUBidDocumentResource):
     pass
@@ -24,7 +18,7 @@ class CompetitiveDialogueEUBidDocumentResource(TenderEUBidDocumentResource):
     name='Competitive Dialogue UA Bid Documents',
     collection_path='/tenders/{tender_id}/bids/{bid_id}/documents',
     path='/tenders/{tender_id}/bids/{bid_id}/documents/{document_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdUA',
+    procurementMethodType=CD_UA_TYPE,
     description="Competitive Dialogue UA bidder documents")
 class CompetitiveDialogueUaBidDocumentResource(TenderEUBidDocumentResource):
     pass

--- a/openprocurement/tender/competitivedialogue/views/cancellation.py
+++ b/openprocurement/tender/competitivedialogue/views/cancellation.py
@@ -1,22 +1,24 @@
 # -*- coding: utf-8 -*-
 from openprocurement.api.utils import opresource
 from openprocurement.tender.openeu.views.cancellation import TenderCancellationResource
-
-
-@opresource(name='Competitive Dialogue UA Cancellations',
-            collection_path='/tenders/{tender_id}/cancellations',
-            path='/tenders/{tender_id}/cancellations/{cancellation_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdUA',
-            description="Competitive Dialogue UA cancellations")
-class CompetitiveDialogueUACancellationResource(TenderCancellationResource):
-    pass
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @opresource(name='Competitive Dialogue EU Cancellations',
             collection_path='/tenders/{tender_id}/cancellations',
             path='/tenders/{tender_id}/cancellations/{cancellation_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdEU',
+            procurementMethodType=CD_EU_TYPE,
             description="Competitive Dialogue UE cancellations")
 class CompetitiveDialogueEUCancellationResource(TenderCancellationResource):
     """ TenderEU Cancellations """
+    pass
+
+
+@opresource(name='Competitive Dialogue UA Cancellations',
+            collection_path='/tenders/{tender_id}/cancellations',
+            path='/tenders/{tender_id}/cancellations/{cancellation_id}',
+            procurementMethodType=CD_UA_TYPE,
+            description="Competitive Dialogue UA cancellations")
+class CompetitiveDialogueUACancellationResource(TenderCancellationResource):
+    """ TenderUA Cancellations """
     pass

--- a/openprocurement/tender/competitivedialogue/views/cancellation_document.py
+++ b/openprocurement/tender/competitivedialogue/views/cancellation_document.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from openprocurement.api.utils import opresource
 from openprocurement.api.views.cancellation_document import TenderCancellationDocumentResource as BaseResource
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @opresource(name='Competitive Dialogue  EU Cancellation Documents',
             collection_path='/tenders/{tender_id}/cancellations/{cancellation_id}/documents',
             path='/tenders/{tender_id}/cancellations/{cancellation_id}/documents/{document_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdEU',
+            procurementMethodType=CD_EU_TYPE,
             description="Competitive Dialogue  EU cancellation documents")
 class CompetitiveDialogueEUCancellationDocumentResource(BaseResource):
     """ Cancellation Document """
@@ -16,7 +17,7 @@ class CompetitiveDialogueEUCancellationDocumentResource(BaseResource):
 @opresource(name='Competitive Dialogue UA Cancellation Documents',
             collection_path='/tenders/{tender_id}/cancellations/{cancellation_id}/documents',
             path='/tenders/{tender_id}/cancellations/{cancellation_id}/documents/{document_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdUA',
+            procurementMethodType=CD_UA_TYPE,
             description="Competitive Dialogue UA cancellation documents")
 class CompetitiveDialogueUACancellationDocumentResource(BaseResource):
     """ Cancellation Document """

--- a/openprocurement/tender/competitivedialogue/views/complaint.py
+++ b/openprocurement/tender/competitivedialogue/views/complaint.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from openprocurement.api.utils import opresource
 from openprocurement.tender.openeu.views.complaint import TenderEUComplaintResource
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @opresource(name='Competitive Dialogue EU Complaints',
             collection_path='/tenders/{tender_id}/complaints',
             path='/tenders/{tender_id}/complaints/{complaint_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdEU',
+            procurementMethodType=CD_EU_TYPE,
             description="Competitive Dialogue EU complaints")
 class CompetitiveDialogueEUComplaintResource(TenderEUComplaintResource):
     pass
@@ -15,8 +16,7 @@ class CompetitiveDialogueEUComplaintResource(TenderEUComplaintResource):
 @opresource(name='Competitive Dialogue UA Complaints',
             collection_path='/tenders/{tender_id}/complaints',
             path='/tenders/{tender_id}/complaints/{complaint_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdUA',
+            procurementMethodType=CD_UA_TYPE,
             description="Competitive Dialogue UA complaints")
 class CompetitiveDialogueUAComplaintResource(TenderEUComplaintResource):
     pass
-

--- a/openprocurement/tender/competitivedialogue/views/complaint_document.py
+++ b/openprocurement/tender/competitivedialogue/views/complaint_document.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from openprocurement.api.utils import opresource
 from openprocurement.tender.openua.views.complaint_document import TenderUaComplaintDocumentResource
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @opresource(name='Competitive Dialogue EU Complaint Documents',
             collection_path='/tenders/{tender_id}/complaints/{complaint_id}/documents',
             path='/tenders/{tender_id}/complaints/{complaint_id}/documents/{document_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdEU',
+            procurementMethodType=CD_EU_TYPE,
             description="Competitive Dialogue complaint documents")
 class CompetitiveDialogueEUComplaintDocumentResource(TenderUaComplaintDocumentResource):
     pass
@@ -15,7 +16,7 @@ class CompetitiveDialogueEUComplaintDocumentResource(TenderUaComplaintDocumentRe
 @opresource(name='Competitive Dialogue UA Complaint Documents',
             collection_path='/tenders/{tender_id}/complaints/{complaint_id}/documents',
             path='/tenders/{tender_id}/complaints/{complaint_id}/documents/{document_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdUA',
+            procurementMethodType=CD_UA_TYPE,
             description="Competitive Dialogue complaint documents")
 class CompetitiveDialogueUAComplaintDocumentResource(TenderUaComplaintDocumentResource):
     pass

--- a/openprocurement/tender/competitivedialogue/views/lot.py
+++ b/openprocurement/tender/competitivedialogue/views/lot.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 from openprocurement.tender.openeu.views.lot import TenderEULotResource as TenderLotResource
-
-from openprocurement.api.utils import (
-    opresource,
-)
+from openprocurement.api.utils import opresource
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @opresource(name='Competitive Dialogue EU Lots',
             collection_path='/tenders/{tender_id}/lots',
             path='/tenders/{tender_id}/lots/{lot_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdEU',
+            procurementMethodType=CD_EU_TYPE,
             description="Competitive Dialogue EU lots")
 class CompetitiveDialogueEULotResource(TenderLotResource):
     pass
@@ -18,7 +16,7 @@ class CompetitiveDialogueEULotResource(TenderLotResource):
 @opresource(name='Competitive Dialogue UA Lots',
             collection_path='/tenders/{tender_id}/lots',
             path='/tenders/{tender_id}/lots/{lot_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdUA',
+            procurementMethodType=CD_UA_TYPE,
             description="Competitive Dialogue UA lots")
 class CompetitiveDialogueUALotResource(TenderLotResource):
     pass

--- a/openprocurement/tender/competitivedialogue/views/qualification.py
+++ b/openprocurement/tender/competitivedialogue/views/qualification.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from openprocurement.tender.openeu.utils import qualifications_resource
 from openprocurement.tender.openeu.views.qualification import TenderQualificationResource
-
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 @qualifications_resource(
     name='Competitive Dialogue EU Qualification',
     collection_path='/tenders/{tender_id}/qualifications',
     path='/tenders/{tender_id}/qualifications/{qualification_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdEU',
+    procurementMethodType=CD_EU_TYPE,
     description="Competitive Dialogue EU Qualification")
 class CompetitiveDialogueEUQualificationResource(TenderQualificationResource):
     pass
@@ -17,7 +17,7 @@ class CompetitiveDialogueEUQualificationResource(TenderQualificationResource):
     name='Competitive Dialogue UA Qualification',
     collection_path='/tenders/{tender_id}/qualifications',
     path='/tenders/{tender_id}/qualifications/{qualification_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdUA',
+    procurementMethodType=CD_UA_TYPE,
     description="Competitive Dialogue UA Qualification")
 class CompetitiveDialogueUAQualificationResource(TenderQualificationResource):
     pass

--- a/openprocurement/tender/competitivedialogue/views/qualification_complaint.py
+++ b/openprocurement/tender/competitivedialogue/views/qualification_complaint.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 from openprocurement.tender.openeu.utils import qualifications_resource
 from openprocurement.tender.openeu.views.qualification_complaint import TenderEUQualificationComplaintResource as BaseTenderQualificationComplaintResource
-
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 @qualifications_resource(
     name='Competitive Dialogue EU Qualification Complaints',
     collection_path='/tenders/{tender_id}/qualifications/{qualification_id}/complaints',
     path='/tenders/{tender_id}/qualifications/{qualification_id}/complaints/{complaint_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdEU',
+    procurementMethodType=CD_EU_TYPE,
     description="Competitive Dialogue EU qualification complaints")
 class CompetitiveDialogueEUQualificationComplaintResource(BaseTenderQualificationComplaintResource):
     pass
@@ -17,7 +17,7 @@ class CompetitiveDialogueEUQualificationComplaintResource(BaseTenderQualificatio
     name='Competitive Dialogue UA Qualification Complaints',
     collection_path='/tenders/{tender_id}/qualifications/{qualification_id}/complaints',
     path='/tenders/{tender_id}/qualifications/{qualification_id}/complaints/{complaint_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdUA',
+    procurementMethodType=CD_UA_TYPE,
     description="Competitive Dialogue UA qualification complaints")
 class CompetitiveDialogueUAQualificationComplaintResource(BaseTenderQualificationComplaintResource):
     pass

--- a/openprocurement/tender/competitivedialogue/views/qualification_complaint_document.py
+++ b/openprocurement/tender/competitivedialogue/views/qualification_complaint_document.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 from openprocurement.tender.openeu.utils import qualifications_resource
 from openprocurement.tender.openeu.views.qualification_complaint_document import TenderEUAwardComplaintDocumentResource as BaseTenderEUAwardComplaintDocumentResource
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @qualifications_resource(
     name='Competitive Dialogue EU Qualification Complaint Documents',
     collection_path='/tenders/{tender_id}/qualifications/{qualification_id}/complaints/{complaint_id}/documents',
     path='/tenders/{tender_id}/qualifications/{qualification_id}/complaints/{complaint_id}/documents/{document_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdEU',
+    procurementMethodType=CD_EU_TYPE,
     description="Competitive Dialogue EU Qualification Complaint Documents")
 class CompetitiveDialogueEUQualificationComplaintDocumentResource(BaseTenderEUAwardComplaintDocumentResource):
     pass
@@ -17,7 +18,7 @@ class CompetitiveDialogueEUQualificationComplaintDocumentResource(BaseTenderEUAw
     name='Competitive Dialogue UA Qualification Complaint Documents',
     collection_path='/tenders/{tender_id}/qualifications/{qualification_id}/complaints/{complaint_id}/documents',
     path='/tenders/{tender_id}/qualifications/{qualification_id}/complaints/{complaint_id}/documents/{document_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdUA',
+    procurementMethodType=CD_UA_TYPE,
     description="Competitive Dialogue UA Qualification Complaint Documents")
 class CompetitiveDialogueUAQualificationComplaintDocumentResource(BaseTenderEUAwardComplaintDocumentResource):
     pass

--- a/openprocurement/tender/competitivedialogue/views/qualification_document.py
+++ b/openprocurement/tender/competitivedialogue/views/qualification_document.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 from openprocurement.tender.openeu.utils import qualifications_resource
-from openprocurement.tender.openeu.views.qualification_document import TenderQualificationDocumentResource as BaseTenderQualificationDocumentResource
+from openprocurement.tender.openeu.views.qualification_document import (
+    TenderQualificationDocumentResource as BaseTenderQualificationDocumentResource)
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @qualifications_resource(
     name='Competitive Dialogue EU Qualification Documents',
     collection_path='/tenders/{tender_id}/qualifications/{qualification_id}/documents',
     path='/tenders/{tender_id}/qualifications/{qualification_id}/documents/{document_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdEU',
+    procurementMethodType=CD_EU_TYPE,
     description="Competitive Dialogue EU Qualification Documents")
 class CompetitiveDialogueEUQualificationDocumentResource(BaseTenderQualificationDocumentResource):
     pass
@@ -17,7 +19,7 @@ class CompetitiveDialogueEUQualificationDocumentResource(BaseTenderQualification
     name='Competitive Dialogue UA Qualification Documents',
     collection_path='/tenders/{tender_id}/qualifications/{qualification_id}/documents',
     path='/tenders/{tender_id}/qualifications/{qualification_id}/documents/{document_id}',
-    procurementMethodType='competitiveDialogue.aboveThresholdUA',
+    procurementMethodType=CD_UA_TYPE,
     description="Competitive Dialogue UA Qualification Documents")
 class CompetitiveDialogueUAQualificationDocumentResource(BaseTenderQualificationDocumentResource):
     pass

--- a/openprocurement/tender/competitivedialogue/views/question.py
+++ b/openprocurement/tender/competitivedialogue/views/question.py
@@ -1,21 +1,22 @@
 # -*- coding: utf-8 -*-
 from openprocurement.tender.openua.views.question import TenderUaQuestionResource as BaseResource
 from openprocurement.api.utils import opresource
-
-
-@opresource(name='Competitive Dialogue UA Questions',
-            collection_path='/tenders/{tender_id}/questions',
-            path='/tenders/{tender_id}/questions/{question_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdUA',
-            description="competitiveDialogue UA questions")
-class CompetitiveDialogueUAQuestionResource(BaseResource):
-    """ TenderEU Questions """
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @opresource(name='Competitive Dialogue EU Questions',
             collection_path='/tenders/{tender_id}/questions',
             path='/tenders/{tender_id}/questions/{question_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdEU',
+            procurementMethodType=CD_EU_TYPE,
             description="competitiveDialogue UE questions")
 class CompetitiveDialogueEUQuestionResource(BaseResource):
     """ TenderEU Questions """
+
+
+@opresource(name='Competitive Dialogue UA Questions',
+            collection_path='/tenders/{tender_id}/questions',
+            path='/tenders/{tender_id}/questions/{question_id}',
+            procurementMethodType=CD_UA_TYPE,
+            description="competitiveDialogue UA questions")
+class CompetitiveDialogueUAQuestionResource(BaseResource):
+    """ TenderUA Questions """

--- a/openprocurement/tender/competitivedialogue/views/tender.py
+++ b/openprocurement/tender/competitivedialogue/views/tender.py
@@ -4,26 +4,27 @@ from openprocurement.tender.openeu.views.tender import TenderEUResource
 from openprocurement.tender.openua.validation import validate_patch_tender_ua_data
 from openprocurement.tender.competitivedialogue.utils import patch_eu
 from openprocurement.api.utils import opresource, json_view
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
-@opresource(name='Competitive Dialogue for UA procedure',
+@opresource(name='Competitive Dialogue for EU procedure',
             path='/tenders/{tender_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdUA',
-            description="Open Contracting compatible data exchange format. See # for more info")
-class CompetitiveDialogueUAResource(TenderResource):
-    """ Resource handler for Competitive Dialogue UA"""
+            procurementMethodType=CD_EU_TYPE,
+            description="Open Contracting compatible data exchange format. See  for more info")
+class CompetitiveDialogueEUResource(TenderEUResource):
+    """ Resource handler for Competitive Dialogue EU"""
 
     @json_view(content_type="application/json", validators=(validate_patch_tender_ua_data,), permission='edit_tender')
     def patch(self):
         return patch_eu(self)
 
 
-@opresource(name='Competitive Dialogue for EU procedure',
+@opresource(name='Competitive Dialogue for UA procedure',
             path='/tenders/{tender_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdEU',
-            description="Open Contracting compatible data exchange format. See  for more info")
-class CompetitiveDialogueEUResource(TenderEUResource):
-    """ Resource handler for Competitive Dialogue EU"""
+            procurementMethodType=CD_UA_TYPE,
+            description="Open Contracting compatible data exchange format. See # for more info")
+class CompetitiveDialogueUAResource(TenderResource):
+    """ Resource handler for Competitive Dialogue UA"""
 
     @json_view(content_type="application/json", validators=(validate_patch_tender_ua_data,), permission='edit_tender')
     def patch(self):

--- a/openprocurement/tender/competitivedialogue/views/tender_document.py
+++ b/openprocurement/tender/competitivedialogue/views/tender_document.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from openprocurement.api.utils import opresource
 from openprocurement.tender.openua.views.tender_document import TenderUaDocumentResource
+from openprocurement.tender.competitivedialogue.models import CD_EU_TYPE, CD_UA_TYPE
 
 
 @opresource(name='Competitive Dialogue EU Documents',
             collection_path='/tenders/{tender_id}/documents',
             path='/tenders/{tender_id}/documents/{document_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdEU',
+            procurementMethodType=CD_EU_TYPE,
             description="Tender EU related binary files (PDFs, etc.)")
 class CompetitiveDialogueEUDocumentResource(TenderUaDocumentResource):
     pass
@@ -15,8 +16,7 @@ class CompetitiveDialogueEUDocumentResource(TenderUaDocumentResource):
 @opresource(name='Competitive Dialogue UA Documents',
             collection_path='/tenders/{tender_id}/documents',
             path='/tenders/{tender_id}/documents/{document_id}',
-            procurementMethodType='competitiveDialogue.aboveThresholdUA',
+            procurementMethodType=CD_UA_TYPE,
             description="Competitive Dialogue UA related binary files (PDFs, etc.)")
 class CompetitiveDialogueUADocumentResource(TenderUaDocumentResource):
     pass
-


### PR DESCRIPTION
Отримали зауваженню від ДЗО - що назва типу (competitiveDialogue.aboveThresholdUA\EU) занадто довга для них. Виконано перейменування   
competitiveDialogue.aboveThresholdUA -> competitiveDialogueUA
competitiveDialogue.aboveThresholdEU -> competitiveDialogueEU

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.tender.competitivedialogue/6)
<!-- Reviewable:end -->
