### PR TITLE
set tenderID for stage2

### DIFF
--- a/openprocurement/tender/competitivedialogue/databridge.py
+++ b/openprocurement/tender/competitivedialogue/databridge.py
@@ -248,7 +248,7 @@ class CompetitiveDialogueDataBridge(object):
                     new_tender['procurementMethodType'] = STAGE_2_EU_TYPE
                 else:
                     new_tender['procurementMethodType'] = STAGE_2_UA_TYPE
-
+                new_tender['tenderID'] = '{}.2'.format(tender['tenderID']) # set tenderID as in stage1 + '.2'
                 old_lots, items, short_listed_firms = dict(), list(), dict()
                 for qualification in tender['qualifications']:
                     if qualification['status'] == 'active':  # check if qualification has status active

--- a/openprocurement/tender/competitivedialogue/models.py
+++ b/openprocurement/tender/competitivedialogue/models.py
@@ -226,7 +226,7 @@ close_edit_technical_fields = blacklist('dialogue_token', 'shortlistedFirms', 'd
 
 stage_2_roles = {
     'plain': plain_role,
-    'create': (blacklist('owner_token', 'tenderPeriod', '_attachments', 'revisions', 'dateModified', 'doc_id', 'tenderID', 'bids', 'documents', 'awards', 'questions', 'complaints', 'auctionUrl', 'status', 'auctionPeriod', 'awardPeriod', 'awardCriteria', 'submissionMethod', 'cancellations') + schematics_embedded_role),
+    'create': (blacklist('owner_token', 'tenderPeriod', '_attachments', 'revisions', 'dateModified', 'doc_id', 'bids', 'documents', 'awards', 'questions', 'complaints', 'auctionUrl', 'status', 'auctionPeriod', 'awardPeriod', 'awardCriteria', 'submissionMethod', 'cancellations') + schematics_embedded_role),
     'edit': whitelist('tenderPeriod'),
     'edit_draft': whitelist('status'),  # only bridge must change only status
     'edit_'+STAGE2_STATUS: whitelist('tenderPeriod', 'status'),


### PR DESCRIPTION
tenderID другого етапу повинен складатися з tenderID першого та + '.2' в кінці.
Залежить від https://github.com/openprocurement/openprocurement.api/pull/104
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.tender.competitivedialogue/46)
<!-- Reviewable:end -->
