### PR TITLE
Fix validation for questions stage2

### DIFF
--- a/openprocurement/tender/competitivedialogue/tests/stage2/question.py
+++ b/openprocurement/tender/competitivedialogue/tests/stage2/question.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 from copy import deepcopy
+from uuid import uuid4
 
 from openprocurement.tender.competitivedialogue.tests.base import (test_lots, test_bids, test_shortlistedFirms,
                                                                    BaseCompetitiveDialogEUStage2ContentWebTest,
@@ -385,6 +386,28 @@ class TenderStage2EUQuestionResourceTest(BaseCompetitiveDialogEUStage2ContentWeb
                 u'url', u'name': u'tender_id'}
         ])
 
+    def create_question_on_item(self):
+        tender = self.db.get(self.tender_id)
+        item = tender['items'][0]
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'item',
+                                                'relatedItem': item['id'],
+                                                'author': author}})
+
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'tender',
+                                                'author': author}})
+
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+
 
 class TenderStage2EULotQuestionResourceTest(BaseCompetitiveDialogEUStage2ContentWebTest):
 
@@ -447,6 +470,56 @@ class TenderStage2EULotQuestionResourceTest(BaseCompetitiveDialogEUStage2Content
              u'location': u'body',
              u'name': u'author'}
         ])
+
+    def create_question_on_item(self):
+        tender = self.db.get(self.tender_id)
+        item = tender['items'][0]
+        new_item = deepcopy(item)
+        new_item['id'] = uuid4().hex
+        new_item['relatedLot'] = self.lots[1]['id']
+        tender['items'] = [item, new_item]
+        for firm in tender['shortlistedFirms']:
+            firm['lots'] = [{'id': self.lots[1]['id']}]
+        self.db.save(tender)
+
+        # Create question on item
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'item',
+                                                'relatedItem': new_item['id'],
+                                                'author': author}})
+
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+
+        # Can't create question on item, on which we haven't access
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'item',
+                                                'relatedItem': item['id'],
+                                                'author': author}},
+                                      status=403)
+
+        self.assertEqual(response.status, '403 Forbidden')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['status'], 'error')
+        self.assertEqual(response.json['errors'], [
+            {u'description': u'Author can\'t create question',
+             u'location': u'body',
+             u'name': u'author'}
+        ])
+
+        # Create question on tender
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'tender',
+                                                'author': author}})
+
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
 
     def test_patch_tender_question(self):
         response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
@@ -875,6 +948,28 @@ class TenderStage2UAQuestionResourceTest(BaseCompetitiveDialogUAStage2ContentWeb
                 u'url', u'name': u'tender_id'}
         ])
 
+    def create_question_on_item(self):
+        tender = self.db.get(self.tender_id)
+        item = tender['items'][0]
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'item',
+                                                'relatedItem': item['id'],
+                                                'author': author}})
+
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'tender',
+                                                'author': author}})
+
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+
 
 class TenderStage2UALotQuestionResourceTest(BaseCompetitiveDialogUAStage2ContentWebTest):
 
@@ -989,6 +1084,56 @@ class TenderStage2UALotQuestionResourceTest(BaseCompetitiveDialogUAStage2Content
         self.assertEqual(response.status, '200 OK')
         self.assertEqual(response.content_type, 'application/json')
         self.assertEqual(response.json['data']["answer"], "answer")
+
+    def create_question_on_item(self):
+        tender = self.db.get(self.tender_id)
+        item = tender['items'][0]
+        new_item = deepcopy(item)
+        new_item['id'] = uuid4().hex
+        new_item['relatedLot'] = self.lots[1]['id']
+        tender['items'] = [item, new_item]
+        for firm in tender['shortlistedFirms']:
+            firm['lots'] = [{'id': self.lots[1]['id']}]
+        self.db.save(tender)
+
+        # Create question on item
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'item',
+                                                'relatedItem': new_item['id'],
+                                                'author': author}})
+
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+
+        # Can't create question on item, on which we haven't access
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'item',
+                                                'relatedItem': item['id'],
+                                                'author': author}},
+                                      status=403)
+
+        self.assertEqual(response.status, '403 Forbidden')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['status'], 'error')
+        self.assertEqual(response.json['errors'], [
+            {u'description': u'Author can\'t create question',
+             u'location': u'body',
+             u'name': u'author'}
+        ])
+
+        # Create question on tender
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'questionOf': 'tender',
+                                                'author': author}})
+
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
 
 
 def suite():

--- a/openprocurement/tender/competitivedialogue/validation.py
+++ b/openprocurement/tender/competitivedialogue/validation.py
@@ -53,10 +53,13 @@ def validate_author(request, shortlistedFirms, obj):
                                                  obj.__class__.__name__.lower())
     firms_keys = prepare_shortlistedFirms(shortlistedFirms)
     author_key = prepare_author(obj)
-    if obj.get('questionOf') == 'item' and shortlistedFirms[0].get('lots'):  # question can create on item
-        item_id = author_key.split('_')[-1]
-        item = get_item_by_id(request.validated['tender'], item_id)
-        author_key = author_key.replace(author_key.split('_')[-1], item['relatedLot'])
+    if obj.get('questionOf') == 'item':
+        if shortlistedFirms[0].get('lots'):  # question can create on item
+            item_id = author_key.split('_')[-1]
+            item = get_item_by_id(request.validated['tender'], item_id)
+            author_key = author_key.replace(author_key.split('_')[-1], item['relatedLot'])
+        else:
+            author_key = '_'.join(author_key.split('_')[:-1])
     for firm in firms_keys:
         if author_key in firm:  # if we found legal firm then check another complaint
             break

--- a/openprocurement/tender/competitivedialogue/validation.py
+++ b/openprocurement/tender/competitivedialogue/validation.py
@@ -42,12 +42,22 @@ def validate_patch_tender_stage2_data(request):
     return data
 
 
+def get_item_by_id(tender, id):
+    for item in tender['items']:
+        if item['id'] == id:
+            return item
+
+
 def validate_author(request, shortlistedFirms, obj):
     error_message = 'Author can\'t {} {}'.format('create' if request.method == 'POST' else 'patch',
                                                  obj.__class__.__name__.lower())
-    firms_key = prepare_shortlistedFirms(shortlistedFirms)
+    firms_keys = prepare_shortlistedFirms(shortlistedFirms)
     author_key = prepare_author(obj)
-    for firm in firms_key:
+    if obj.get('questionOf') == 'item' and shortlistedFirms[0].get('lots'):  # question can create on item
+        item_id = author_key.split('_')[-1]
+        item = get_item_by_id(request.validated['tender'], item_id)
+        author_key = author_key.replace(author_key.split('_')[-1], item['relatedLot'])
+    for firm in firms_keys:
         if author_key in firm:  # if we found legal firm then check another complaint
             break
     else:  # we didn't find legal firm, then return error


### PR DESCRIPTION
Питання можуть бути 3 типів.
1 - До tender
2 - До item
3 - До lot

Обновив валідацію, теперь якщо учасник допущен до переговорів він може задати питання до тендеру, до лотів на які допущен, та до item які мають relatedLot на які допущен учасник.

Додав тести, щоб покрити всі сценарії.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.tender.competitivedialogue/49)
<!-- Reviewable:end -->
