### PR TITLE
Виправлення багу для запитань другого етапу

### DIFF
--- a/openprocurement/tender/competitivedialogue/tests/stage2/question.py
+++ b/openprocurement/tender/competitivedialogue/tests/stage2/question.py
@@ -208,6 +208,42 @@ class TenderStage2EUQuestionResourceTest(BaseCompetitiveDialogEUStage2ContentWeb
         self.assertEqual(response.json['errors'], [
             {u'description': u'Author can\'t create question', u'location': u'body', u'name': u'author'}])
 
+    def test_create_tender_question_with_questionOf(self):
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'author': author,
+                                                'questionOf': 'tender',
+                                                'relatedItem': self.tender_id}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        question = response.json['data']
+        self.assertEqual(question['author']['name'], author['name'])
+        self.assertIn('id', question)
+        self.assertIn(question['id'], response.headers['Location'])
+
+        self.time_shift('enquiryPeriod_ends')
+
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'author': author}},
+                                      status=403)
+        self.assertEqual(response.status, '403 Forbidden')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['errors'][0]["description"], "Can add question only in enquiryPeriod")
+
+        self.time_shift('active.pre-qualification')
+        self.check_chronograph()
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'author': author}},
+                                      status=403)
+        self.assertEqual(response.status, '403 Forbidden')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['errors'][0]["description"], "Can add question only in enquiryPeriod")
+
     def test_create_tender_question(self):
         response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
                                       {'data': {'title': 'question title',
@@ -769,6 +805,42 @@ class TenderStage2UAQuestionResourceTest(BaseCompetitiveDialogUAStage2ContentWeb
         self.assertEqual(response.json['status'], 'error')
         self.assertEqual(response.json['errors'], [
             {u'description': u'Author can\'t create question', u'location': u'body', u'name': u'author'}])
+
+    def test_create_tender_question_with_questionOf(self):
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'author': author,
+                                                'questionOf': 'tender',
+                                                'relatedItem': self.tender_id}})
+        self.assertEqual(response.status, '201 Created')
+        self.assertEqual(response.content_type, 'application/json')
+        question = response.json['data']
+        self.assertEqual(question['author']['name'], author['name'])
+        self.assertIn('id', question)
+        self.assertIn(question['id'], response.headers['Location'])
+
+        self.time_shift('enquiryPeriod_ends')
+
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'author': author}},
+                                      status=403)
+        self.assertEqual(response.status, '403 Forbidden')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['errors'][0]["description"], "Can add question only in enquiryPeriod")
+
+        self.time_shift('active.pre-qualification')
+        self.check_chronograph()
+        response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),
+                                      {'data': {'title': 'question title',
+                                                'description': 'question description',
+                                                'author': author}},
+                                      status=403)
+        self.assertEqual(response.status, '403 Forbidden')
+        self.assertEqual(response.content_type, 'application/json')
+        self.assertEqual(response.json['errors'][0]["description"], "Can add question only in enquiryPeriod")
 
     def test_create_tender_question(self):
         response = self.app.post_json('/tenders/{}/questions'.format(self.tender_id),

--- a/openprocurement/tender/competitivedialogue/utils.py
+++ b/openprocurement/tender/competitivedialogue/utils.py
@@ -227,9 +227,15 @@ def prepare_shortlistedFirms(shortlistedFirms):
 
 
 def prepare_author(obj):
+    """ Make key
+        {author.identifier.id}_{author.identifier.scheme}
+        or
+        {author.identifier.id}_{author.identifier.scheme}_{lot.id}
+        if obj has relatedItem and questionOf != tender or obj has relatedLot than
+    """
     base_key = u"{id}_{scheme}".format(scheme=obj['author']['identifier']['scheme'],
                                        id=obj['author']['identifier']['id'])
-    if obj.get('relatedLot') or obj.get('relatedItem'):
+    if obj.get('relatedLot') or (obj.get('relatedItem') and obj.get('questionOf') == 'lot'):
         base_key = u"{base_key}_{lotId}".format(base_key=base_key,
                                                 lotId=obj.get('relatedLot') or obj.get('relatedItem'))
     return base_key

--- a/openprocurement/tender/competitivedialogue/validation.py
+++ b/openprocurement/tender/competitivedialogue/validation.py
@@ -49,12 +49,13 @@ def get_item_by_id(tender, id):
 
 
 def validate_author(request, shortlistedFirms, obj):
+    """ Compare author key and key from shortlistedFirms """
     error_message = 'Author can\'t {} {}'.format('create' if request.method == 'POST' else 'patch',
                                                  obj.__class__.__name__.lower())
     firms_keys = prepare_shortlistedFirms(shortlistedFirms)
     author_key = prepare_author(obj)
-    if obj.get('questionOf') == 'item':
-        if shortlistedFirms[0].get('lots'):  # question can create on item
+    if obj.get('questionOf') == 'item':  # question can create on item
+        if shortlistedFirms[0].get('lots'):
             item_id = author_key.split('_')[-1]
             item = get_item_by_id(request.validated['tender'], item_id)
             author_key = author_key.replace(author_key.split('_')[-1], item['relatedLot'])
@@ -68,6 +69,7 @@ def validate_author(request, shortlistedFirms, obj):
         request.errors.status = 403
         return False
     return True
+
 
 def validate_complaint_data_stage2(request):
     if not request.check_accreditation(request.tender.edit_accreditation):


### PR DESCRIPTION
Коли користувач, який був допущений до другого етапу намагався створити запитання на тендер та передав полями questionOf = 'tender' relatedItem = tender.id то виникала помилка якої не повино бути.
Помилку прибрав, та покрив тестами.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.tender.competitivedialogue/86)
<!-- Reviewable:end -->
